### PR TITLE
CloudformationOverrideFile

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	DeploymentType       string `json:"deploymentType"`
 	ArtifactBucket       string `json:"artifactBucket"`
 	CustomCloudformation string `json:"customCloudformation"`
+	CloudformationOverrideFile string `json:"cloudformationOverrideFile"`
 
 	// Note, leave empty to use the default. This is really for migrations only.
 	CloudformationStackName string `json:"cloudformationStackName"`

--- a/main.go
+++ b/main.go
@@ -174,8 +174,15 @@ func buildArtifact(c config.Config) {
 	err = ioutil.WriteFile(filepath.Join(target, "riff-raff.yaml"), rrOutput, os.ModePerm)
 	check(err, "Unable to write riff-raff.yaml file.")
 
-	err = ioutil.WriteFile(filepath.Join(target, "cfn", "cfn.yaml"), []byte(tpl.AlbEc2Stack), os.ModePerm)
-	check(err, "Unable to write cfn.yaml file.")
+	if c.CloudformationOverrideFile != "" {
+		cfnOverride, err := ioutil.ReadFile(c.CloudformationOverrideFile)
+		check(err, "Unable to read cloudformation override file.")
+		err = ioutil.WriteFile(target+"/cfn/cfn.yaml", cfnOverride, os.ModePerm)
+		check(err, "Unable to write cfn.yaml override file.")
+	} else {
+		err = ioutil.WriteFile(filepath.Join(target, "cfn", "cfn.yaml"), []byte(tpl.AlbEc2Stack), os.ModePerm)
+		check(err, "Unable to write cfn.yaml file.")
+	}
 
 	if c.CustomCloudformation != "" {
 		makeDir(target, "customCfn")


### PR DESCRIPTION
Allows you to optionally override the default cloudformation file with your own.
We need this for a temporary change to the LaunchConfiguration settings, and we don't want to add support for these particular settings in nest.
It means we can copy the current cloudformation template into our repo and modify it