### PR TITLE
set ulimit nofile

### DIFF
--- a/cdk/stacks/AlbEc2Stack.ts
+++ b/cdk/stacks/AlbEc2Stack.ts
@@ -194,6 +194,7 @@ export class AlbEc2Stack extends cdk.Stack {
             `aws s3 cp s3://${s3Bucket.valueAsString}/${s3Key.valueAsString} app.tar.gz`,
             `docker load < app.tar.gz`,
             `docker run \
+            --ulimit nofile=2048:2048 \
             --env-file .env \
             -p 3030:3030 \
             --log-driver=awslogs \


### PR DESCRIPTION
dotcom-components (node server) is reached the socket limit and failing with:
```
Error: accept EMFILE
    at TCP.onconnection (net.js:1536:24)
Emitted 'error' event on Server instance at:
    at TCP.onconnection (net.js:1536:10) {
  errno: 'EMFILE',
  code: 'EMFILE',
  syscall: 'accept'
```

The current value is 1024